### PR TITLE
feat: add maubot rock

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,3 +13,4 @@ jobs:
       juju-channel: 3.4/stable
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,5 +11,5 @@ jobs:
       channel: 1.28-strict/stable
       charmcraft-channel: latest/edge
       juju-channel: 3.4/stable
-      self-hosted-runner: true
+      self-hosted-runner: false
       self-hosted-runner-label: "edge"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,4 +13,3 @@ jobs:
       juju-channel: 3.4/stable
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
-      tmate-debug: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,5 +9,4 @@ jobs:
     secrets: inherit
     with:
       charmcraft-channel: latest/edge
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -9,6 +9,7 @@ header:
     - '**'
   paths-ignore:
     - '.github/**'
+    - '.trivyignore'
     - '**/*.json'
     - '**/*.md'
     - '**/*.txt'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Pebble CVE
+CVE-2024-34156

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,4 @@
-# Pebble CVE
+# Pebble CVE - Go project issue
+# Calling Decoder.Decode on a message which contains deeply nested 
+# structures can cause a panic due to stack exhaustion.
 CVE-2024-34156

--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -4,16 +4,29 @@
 name: maubot
 summary: Maubot rock
 description: Maubot OCI image for the Maubot charm
-version: "1.0"
+version: "0.5.0"
 license: Apache-2.0
 
-base: ubuntu@22.04
-build-base: ubuntu@22.04
+base: ubuntu@24.04
+build-base: ubuntu@24.04
 platforms:
   amd64:  
 
+environment: 
+  PYTHONPATH: /opt/maubot/python/dist
+
 parts:
-  hello:
+  maubot:
     plugin: nil
-    stage-packages:
-      - hello
+    build-packages:
+      - wget
+      - ssl-cert
+      - git
+    overlay-packages:
+      - python3-pip
+    overlay-script: |
+      mkdir -p $CRAFT_PART_INSTALL/opt/maubot/python/dist
+      pip install --target=${CRAFT_PART_INSTALL}/opt/maubot/python/dist  'maubot==0.5.0'
+      rm usr/bin/pip*
+    stage:
+      - opt/maubot/python/dist

--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -10,23 +10,16 @@ license: Apache-2.0
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 platforms:
-  amd64:  
+  amd64:
 
-environment: 
-  PYTHONPATH: /opt/maubot/python/dist
+environment:
+  PYTHONPATH: /usr/lib/python3.12/site-packages/
 
 parts:
   maubot:
-    plugin: nil
-    build-packages:
-      - wget
-      - ssl-cert
-      - git
-    overlay-packages:
-      - python3-pip
-    overlay-script: |
-      mkdir -p $CRAFT_PART_INSTALL/opt/maubot/python/dist
-      pip install --target=${CRAFT_PART_INSTALL}/opt/maubot/python/dist  'maubot==0.5.0'
-      rm usr/bin/pip*
-    stage:
-      - opt/maubot/python/dist
+    plugin: python
+    source: .
+    stage-packages:
+      - python3-venv
+    python-packages:
+      - maubot==0.5.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,7 @@ class MaubotCharm(ops.CharmBase):
                 MAUBOT_SERVICE_NAME: {
                     "override": "replace",
                     "summary": "maubot",
-                    "command": 'bash -c "hello -t; sleep 10"',
+                    "command": 'bash -c "python3 -c "import maubot"; sleep 10"',
                     "startup": "enabled",
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,7 @@ class MaubotCharm(ops.CharmBase):
                 MAUBOT_SERVICE_NAME: {
                     "override": "replace",
                     "summary": "maubot",
-                    "command": 'bash -c "python3 -c "import maubot"; sleep 10"',
+                    "command": 'bash -c "python3 -c \'import maubot\'; sleep 10"',
                     "startup": "enabled",
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,13 +32,11 @@ class MaubotCharm(ops.CharmBase):
         self.framework.observe(self.on.maubot_pebble_ready, self._on_maubot_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
-    def _on_maubot_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
-        """Handle maubot pebble ready event.
-
-        Args:
-            event: event triggering the handler.
-        """
-        container = event.workload
+    def _on_maubot_pebble_ready(self, _: ops.PebbleReadyEvent) -> None:
+        """Handle maubot pebble ready event."""
+        container = self.unit.get_container(MAUBOT_CONTAINER_NAME)
+        if not container.can_connect():
+            return
         container.add_layer(MAUBOT_CONTAINER_NAME, self._pebble_layer, combine=True)
         container.replan()
         self.unit.status = ops.ActiveStatus()
@@ -47,6 +45,8 @@ class MaubotCharm(ops.CharmBase):
         """Handle changed configuration."""
         self.unit.status = ops.MaintenanceStatus()
         container = self.unit.get_container(MAUBOT_CONTAINER_NAME)
+        if not container.can_connect():
+            return
         container.add_layer(MAUBOT_SERVICE_NAME, self._pebble_layer, combine=True)
         container.replan()
         self.unit.status = ops.ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,7 @@ class MaubotCharm(ops.CharmBase):
                 MAUBOT_SERVICE_NAME: {
                     "override": "replace",
                     "summary": "maubot",
-                    "command": 'bash -c "python3 -c \'import maubot\'; sleep 10"',
+                    "command": "bash -c \"python3 -c 'import maubot'; sleep 10\"",
                     "startup": "enabled",
                 }
             },

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -35,7 +35,7 @@ class TestCharm(unittest.TestCase):
                 "maubot": {
                     "override": "replace",
                     "summary": "maubot",
-                    "command": 'bash -c "python3 -c "import maubot"; sleep 10"',
+                    "command": "bash -c \"python3 -c 'import maubot'; sleep 10\"",
                     "startup": "enabled",
                 }
             },

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -35,7 +35,7 @@ class TestCharm(unittest.TestCase):
                 "maubot": {
                     "override": "replace",
                     "summary": "maubot",
-                    "command": 'bash -c "hello -t; sleep 10"',
+                    "command": 'bash -c "python3 -c "import maubot"; sleep 10"',
                     "startup": "enabled",
                 }
             },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Maubot is a python application. This PR creates a rock for it.

Reference:
https://docs.mau.fi/maubot/usage/setup/index.html

### Rationale

Create a rock to be published as a charm resource.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No CH available yet.