### PR TITLE
feat: add NGINX rock

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -10,6 +10,7 @@ header:
   paths-ignore:
     - '.github/**'
     - '.trivyignore'
+    - '**/*.conf'
     - '**/*.json'
     - '**/*.md'
     - '**/*.txt'

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,10 +17,15 @@ resources:
   maubot-image:
     type: oci-image
     description: OCI image for maubot
+  maubot-nginx-image:
+    type: oci-image
+    description: OCI image for nginx Maubot
 
 containers:
   maubot:
     resource: maubot-image
+  maubot-nginx:
+    resource: maubot-nginx-image
 
 type: charm
 base: ubuntu@24.04

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -1,0 +1,70 @@
+user nginx nginx;
+daemon off;
+
+events {
+  worker_connections 1024;
+}
+http {
+  include mime.types;
+  server_tokens off;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_min_length 256;
+
+  gzip_proxied any;
+  gzip_http_version 1.1;
+  gzip_types
+   application/font-woff
+   application/font-woff2
+   application/x-javascript
+   application/xml
+   application/xml+rss
+   image/png
+   image/x-icon
+   font/woff2
+   text/css
+   text/javascript
+   text/plain
+   text/xml;
+
+  add_header X-Content-Type-Options 'nosniff';
+  add_header X-Frame-Options 'SAMEORIGIN';
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  add_header X-XSS-Protection "1; mode=block";
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+					'$status $body_bytes_sent "$http_referer" '
+					'"$http_user_agent" "$http_x_forwarded_for" "$http_x_forwarded_proto"';
+  access_log /var/log/nginx/access.log main;
+
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+	  default $http_x_forwarded_proto;
+	  '' $scheme;
+    }
+
+  server {
+    listen 8080;
+    listen [::]:8080;
+    error_log stderr error;
+
+    location / {
+      root /var/empty/nginx;
+      proxy_hide_header Cache-Control;
+      add_header Cache-Control 'no-cache,private';
+      include common_headers.conf;
+      client_max_body_size 0;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass http://localhost:29316;
+    }
+
+    location /health {
+      access_log off;
+      add_header 'Content-Type' 'application/json';
+      return 204;
+    }
+
+  }
+}

--- a/nginx_rock/etc/nginx.conf
+++ b/nginx_rock/etc/nginx.conf
@@ -52,7 +52,6 @@ http {
       root /var/empty/nginx;
       proxy_hide_header Cache-Control;
       add_header Cache-Control 'no-cache,private';
-      include common_headers.conf;
       client_max_body_size 0;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_set_header X-Forwarded-Host $http_host;

--- a/nginx_rock/rockcraft.yaml
+++ b/nginx_rock/rockcraft.yaml
@@ -1,0 +1,35 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: maubot-nginx
+summary: maubot nginx rock
+description: Nginx OCI image for the maubot charm
+version: "1.0"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+license: Apache-2.0
+platforms:
+  amd64:
+parts:
+  add-user:
+    plugin: nil
+    overlay-script: |
+      chmod 755 $CRAFT_OVERLAY/etc
+      groupadd -R $CRAFT_OVERLAY --gid 2000 nginx
+      useradd -R $CRAFT_OVERLAY --system --gid 2000 --uid 2000 --no-create-home nginx
+  nginx-conf:
+    plugin: dump
+    source: etc
+    organize:
+      nginx.conf: etc/nginx/nginx.conf
+  nginx:
+    stage-packages:
+      - logrotate
+      - nginx
+    plugin: nil
+    override-build: |
+      craftctl default
+      rm $CRAFT_PART_INSTALL/etc/nginx/nginx.conf
+    override-prime: |
+      craftctl default
+      mkdir run

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -9,6 +9,7 @@ Maubot charm service.
 ---------------
 - **MAUBOT_SERVICE_NAME**
 - **MAUBOT_CONTAINER_NAME**
+- **NGINX_NAME**
 
 
 ---
@@ -16,7 +17,7 @@ Maubot charm service.
 ## <kbd>class</kbd> `MaubotCharm`
 Maubot charm. 
 
-<a href="../src/charm.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,7 @@ class MaubotCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
-        self.ingress = IngressPerAppRequirer(self, port=29316)
+        self.ingress = IngressPerAppRequirer(self, port=8080)
         self.framework.observe(self.on.maubot_pebble_ready, self._on_maubot_pebble_ready)
         self.framework.observe(
             self.on.maubot_nginx_pebble_ready, self._on_maubot_nginx_pebble_ready

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,4 @@ def pytest_addoption(parser):
     """
     parser.addoption("--charm-file", action="store")
     parser.addoption("--maubot-image", action="store")
+    parser.addoption("--maubot-nginx-image", action="store")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,10 +26,15 @@ async def test_build_and_deploy(
     charm = pytestconfig.getoption("--charm-file")
     maubot_image = pytestconfig.getoption("--maubot-image")
     assert maubot_image
+    maubot_nginx_image = pytestconfig.getoption("--maubot-nginx-image")
+    assert maubot_nginx_image
     if not charm:
         charm = await ops_test.build_charm(".")
     assert ops_test.model
-    maubot = await ops_test.model.deploy(f"./{charm}", resources={"maubot-image": maubot_image})
+    maubot = await ops_test.model.deploy(
+        f"./{charm}",
+        resources={"maubot-image": maubot_image, "maubot-nginx-image": maubot_nginx_image},
+    )
     nginx_ingress_integrator = await ops_test.model.deploy(
         "nginx-ingress-integrator",
         channel="edge",

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -37,14 +37,41 @@ class TestCharm(unittest.TestCase):
                     "summary": "maubot",
                     "command": "bash -c \"python3 -c 'import maubot'; sleep 10\"",
                     "startup": "enabled",
-                }
+                },
             },
         }
 
         self.harness.container_pebble_ready("maubot")
+        self.harness.container_pebble_ready("maubot-nginx")
 
         updated_plan = self.harness.get_container_pebble_plan("maubot").to_dict()
         self.assertEqual(expected_plan, updated_plan)
         service = self.harness.model.unit.get_container("maubot").get_service("maubot")
+        self.assertTrue(service.is_running())
+        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+
+    def test_maubot_nginx_pebble_ready(self):
+        """
+        arrange: initialize the testing harness.
+        act: retrieve the pebble plan for maubot nginx.
+        assert: ensure the maubot nginx pebble plan matches the expectations,
+            the service is running and the charm is active.
+        """
+        expected_plan = {
+            "services": {
+                "maubot-nginx": {
+                    "override": "replace",
+                    "summary": "Maubot NGINX service",
+                    "command": "/usr/sbin/nginx",
+                    "startup": "enabled",
+                },
+            },
+        }
+
+        self.harness.container_pebble_ready("maubot-nginx")
+
+        updated_plan = self.harness.get_container_pebble_plan("maubot-nginx").to_dict()
+        self.assertEqual(expected_plan, updated_plan)
+        service = self.harness.model.unit.get_container("maubot-nginx").get_service("maubot-nginx")
         self.assertTrue(service.is_running())
         self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR adds a NGINX rock and pebble layer to the Maubot charm.

### Rationale

NGINX will act as a proxy.

Note:
- PRs #7 and #8 will add Ingress and PostgreSQL , providing the actual Maubot application.
- Further PR will change Maubot layer to run under daemon user, set IngressRequires properly and also add an integration test for checking the URL.

### Juju Events Changes

Add NGINX pebble ready event.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No CH available.