### PR TITLE
chores: add nginx to maubot

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -10,6 +10,7 @@ header:
   paths-ignore:
     - '.github/**'
     - '.trivyignore'
+    - '**/*.conf'
     - '**/*.json'
     - '**/*.md'
     - '**/*.txt'

--- a/maubot_rock/etc/nginx.conf
+++ b/maubot_rock/etc/nginx.conf
@@ -1,0 +1,68 @@
+user nginx nginx;
+daemon off;
+
+events {
+  worker_connections 1024;
+}
+http {
+  include mime.types;
+  server_tokens off;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_min_length 256;
+
+  gzip_proxied any;
+  gzip_http_version 1.1;
+  gzip_types
+   application/font-woff
+   application/font-woff2
+   application/x-javascript
+   application/xml
+   application/xml+rss
+   image/x-icon
+   font/woff2
+   text/css
+   text/javascript
+   text/plain
+   text/xml;
+
+  add_header X-Content-Type-Options 'nosniff';
+  add_header X-Frame-Options 'SAMEORIGIN';
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  add_header X-XSS-Protection "1; mode=block";
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+					'$status $body_bytes_sent "$http_referer" '
+					'"$http_user_agent" "$http_x_forwarded_for" "$http_x_forwarded_proto"';
+  access_log stdout main;
+
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+	  default $http_x_forwarded_proto;
+	  '' $scheme;
+    }
+
+  server {
+    listen 8080;
+    listen [::]:8080;
+    error_log stderr error;
+
+    location / {
+      root /var/empty/nginx;
+      proxy_hide_header Cache-Control;
+      add_header Cache-Control 'no-cache,private';
+      client_max_body_size 0;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass http://localhost:29316;
+    }
+
+    location /health {
+      access_log off;
+      add_header 'Content-Type' 'application/json';
+      return 204;
+    }
+
+  }
+}

--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -16,6 +16,28 @@ environment:
   PYTHONPATH: /usr/lib/python3.12/site-packages/
 
 parts:
+  add-user:
+    plugin: nil
+    overlay-script: |
+      chmod 755 $CRAFT_OVERLAY/etc
+      groupadd -R $CRAFT_OVERLAY --gid 2000 nginx
+      useradd -R $CRAFT_OVERLAY --system --gid 2000 --uid 2000 --no-create-home nginx
+  nginx-conf:
+    plugin: dump
+    source: etc
+    organize:
+      nginx.conf: etc/nginx/nginx.conf
+  nginx:
+    stage-packages:
+      - logrotate
+      - nginx
+    plugin: nil
+    override-build: |
+      craftctl default
+      rm $CRAFT_PART_INSTALL/etc/nginx/nginx.conf
+    override-prime: |
+      craftctl default
+      mkdir run
   maubot:
     plugin: python
     source: .

--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -16,7 +16,7 @@ environment:
   PYTHONPATH: /usr/lib/python3.12/site-packages/
 
 parts:
-  add-user:
+  nginx-user:
     plugin: nil
     overlay-script: |
       chmod 755 $CRAFT_OVERLAY/etc

--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -35,9 +35,6 @@ parts:
     override-build: |
       craftctl default
       rm $CRAFT_PART_INSTALL/etc/nginx/nginx.conf
-    override-prime: |
-      craftctl default
-      mkdir run
   maubot:
     plugin: python
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,13 +144,20 @@ class MaubotCharm(ops.CharmBase):
             "summary": "maubot layer",
             "description": "pebble config layer for maubot",
             "services": {
+                "nginx": {
+                    "override": "replace",
+                    "summary": "nginx",
+                    "command": "/usr/sbin/nginx",
+                    "startup": "enabled",
+                    "after": [MAUBOT_NAME],
+                },
                 MAUBOT_NAME: {
                     "override": "replace",
                     "summary": "maubot",
                     "command": "python3 -m maubot -c /data/config.yaml",
                     "startup": "enabled",
                     "working-dir": "/data",
-                }
+                },
             },
         }
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,7 @@ class MaubotCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
-        self.ingress = IngressPerAppRequirer(self, port=29316)
+        self.ingress = IngressPerAppRequirer(self, port=8080)
         self.postgresql = DatabaseRequires(
             self, relation_name="postgresql", database_name=self.app.name
         )
@@ -60,26 +60,18 @@ class MaubotCharm(ops.CharmBase):
 
         Args:
             container: Container of the charm.
-
-        Raises:
-            ExecError: something went wrong executing command.
-            PathError: error while interacting with path.
         """
         commands = [
             ["cp", "--update=none", "/example-config.yaml", "/data/config.yaml"],
             ["mkdir", "-p", "/data/plugins", "/data/trash", "/data/dbs"],
         ]
-        try:
-            for command in commands:
-                process = container.exec(command, combine_stderr=True)
-                process.wait()
-            config_content = str(container.pull("/data/config.yaml", encoding="utf-8").read())
-            config = yaml.safe_load(config_content)
-            config["database"] = self._get_postgresql_credentials()
-            container.push("/data/config.yaml", yaml.safe_dump(config))
-        except (ops.pebble.ExecError, ops.pebble.PathError) as exc:
-            logger.exception("Failed to execute command: %r", exc)
-            raise
+        for command in commands:
+            process = container.exec(command, combine_stderr=True)
+            process.wait()
+        config_content = str(container.pull("/data/config.yaml", encoding="utf-8").read())
+        config = yaml.safe_load(config_content)
+        config["database"] = self._get_postgresql_credentials()
+        container.push("/data/config.yaml", yaml.safe_dump(config))
 
     def _reconcile(self) -> None:
         """Reconcile workload configuration."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -64,7 +64,14 @@ def test_maubot_pebble_ready(harness):
                 "command": "python3 -m maubot -c /data/config.yaml",
                 "startup": "enabled",
                 "working-dir": "/data",
-            }
+            },
+            "nginx": {
+                "override": "replace",
+                "summary": "nginx",
+                "command": "/usr/sbin/nginx",
+                "startup": "enabled",
+                "after": ["maubot"],
+            },
         },
     }
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Move NGINX to Maubot as suggested in https://github.com/canonical/maubot-operator/pull/9 by @weiiwang01 

Also remove handling exception raised by Pebble, leaving them to raise as Juju errors. The charm handle only exceptions if the user can take action. Catched it [here](https://github.com/canonical/maubot-operator/pull/7#discussion_r1764000878) by @Thanhphan1147 


### Rationale

Use only one container for Maubot.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
