### PR TITLE
feat: add matrix-auth integration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -55,6 +55,9 @@ assumes:
   - juju >= 3.4
 
 requires:
+  matrix-auth:
+    interface: matrix-auth
+    limit: 1
   postgresql:
     interface: postgresql_client
     limit: 1

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -46,7 +46,7 @@ platforms:
   amd64:
 requires:
   matrix-auth:
-    interface: matrix-auth
+    interface: matrix_auth
     limit: 1
   postgresql:
     interface: postgresql_client

--- a/lib/charms/synapse/v0/matrix_auth.py
+++ b/lib/charms/synapse/v0/matrix_auth.py
@@ -1,0 +1,476 @@
+# Copyright 2024 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+
+"""Library to manage the plugin integrations with the Synapse charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `matrix_plugin` integration.
+
+### Requirer Charm
+
+```python
+
+from charms.synapse.v0.matrix_auth import MatrixAuthRequires
+
+class MatrixAuthRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.plugin_auth = MatrixAuthRequires(self)
+        self.framework.observe(self.matrix_auth.on.matrix_auth_request_processed, self._handler)
+        ...
+
+    def _handler(self, events: MatrixAuthRequestProcessed) -> None:
+        ...
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which a matrix authentication (homeserver and shared secret) has been added or updated.
+
+The MatrixAuthRequires provides an `update_relation_data` method to update the relation data by
+passing a `MatrixAuthRequirerData` data object, requesting a new authentication.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.synapse.v0.matrix_auth import MatrixAuthProvides
+
+class MatrixAuthProviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.plugin_auth = MatrixAuthProvides(self)
+        ...
+
+```
+The MatrixAuthProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+a `MatrixAuthRelationData` data object.
+
+```python
+class MatrixAuthProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        for relation in self.model.relations[self.plugin_auth.relation_name]:
+            self.plugin_auth.update_relation_data(relation, self._get_matrix_auth_data())
+
+```
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "ff6788c89b204448b3b62ba6f93e2768"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# pylint: disable=wrong-import-position
+import json
+import logging
+from typing import Dict, List, Optional, Tuple, cast
+
+import ops
+from pydantic import BaseModel, Field, SecretStr
+
+logger = logging.getLogger(__name__)
+
+#### Constants ####
+APP_REGISTRATION_LABEL = "app-registration"
+APP_REGISTRATION_CONTENT_LABEL = "app-registration-content"
+DEFAULT_RELATION_NAME = "matrix-auth"
+SHARED_SECRET_LABEL = "shared-secret"
+SHARED_SECRET_CONTENT_LABEL = "shared-secret-content"
+
+
+#### Data models for Provider and Requirer ####
+class MatrixAuthProviderData(BaseModel):
+    """Represent the MatrixAuth provider data.
+
+    Attributes:
+        homeserver: the homeserver URL.
+        shared_secret: the Matrix shared secret.
+        shared_secret_id: the shared secret Juju secret ID.
+    """
+
+    homeserver: str
+    shared_secret: Optional[SecretStr] = Field(default=None, exclude=True)
+    shared_secret_id: Optional[SecretStr] = Field(default=None)
+
+    def set_shared_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:
+        """Store the Matrix shared secret as a Juju secret.
+
+        Args:
+            model: the Juju model
+            relation: relation to grant access to the secrets to.
+        """
+        # password is always defined since pydantic guarantees it
+        password = cast(SecretStr, self.shared_secret)
+        # pylint doesn't like get_secret_value
+        secret_value = password.get_secret_value()  # pylint: disable=no-member
+        try:
+            secret = model.get_secret(label=SHARED_SECRET_LABEL)
+            secret.set_content({SHARED_SECRET_CONTENT_LABEL: secret_value})
+            # secret.id is not None at this point
+            self.shared_secret_id = cast(str, secret.id)
+        except ops.SecretNotFoundError:
+            secret = relation.app.add_secret(
+                {SHARED_SECRET_CONTENT_LABEL: secret_value}, label=SHARED_SECRET_LABEL
+            )
+            secret.grant(relation)
+            self.shared_secret_id = cast(str, secret.id)
+
+    @classmethod
+    def get_shared_secret(
+        cls, model: ops.Model, shared_secret_id: Optional[str]
+    ) -> Optional[SecretStr]:
+        """Retrieve the shared secret corresponding to the shared_secret_id.
+
+        Args:
+            model: the Juju model.
+            shared_secret_id: the secret ID for the shared secret.
+
+        Returns:
+            the shared secret or None if not found.
+        """
+        if not shared_secret_id:
+            return None
+        try:
+            secret = model.get_secret(id=shared_secret_id)
+            password = secret.get_content().get(SHARED_SECRET_CONTENT_LABEL)
+            if not password:
+                return None
+            return SecretStr(password)
+        except ops.SecretNotFoundError:
+            return None
+
+    def to_relation_data(self, model: ops.Model, relation: ops.Relation) -> Dict[str, str]:
+        """Convert an instance of MatrixAuthProviderData to the relation representation.
+
+        Args:
+            model: the Juju model.
+            relation: relation to grant access to the secrets to.
+
+        Returns:
+            Dict containing the representation.
+        """
+        self.set_shared_secret_id(model, relation)
+        return self.model_dump(exclude_unset=True)
+
+    @classmethod
+    def from_relation(cls, model: ops.Model, relation: ops.Relation) -> "MatrixAuthProviderData":
+        """Initialize a new instance of the MatrixAuthProviderData class from the relation.
+
+        Args:
+            relation: the relation.
+
+        Returns:
+            A MatrixAuthProviderData instance.
+
+        Raises:
+            ValueError: if the value is not parseable.
+        """
+        app = cast(ops.Application, relation.app)
+        relation_data = relation.data[app]
+        shared_secret_id = (
+            (relation_data["shared_secret_id"])
+            if "shared_secret_id" in relation_data
+            else None
+        )
+        shared_secret = MatrixAuthProviderData.get_shared_secret(model, shared_secret_id)
+        homeserver = relation_data.get("homeserver")
+        if shared_secret is None or homeserver is None:
+            raise ValueError("Invalid relation data")
+        return MatrixAuthProviderData(
+            homeserver=homeserver,
+            shared_secret=shared_secret,
+        )
+
+
+class MatrixAuthRequirerData(BaseModel):
+    """Represent the MatrixAuth requirer data.
+
+    Attributes:
+        registration: a generated app registration file.
+        registration_id: the registration Juju secret ID.
+    """
+
+    registration: Optional[SecretStr] = Field(default=None, exclude=True)
+    registration_secret_id: Optional[SecretStr] = Field(default=None)
+
+    def set_registration_id(self, model: ops.Model, relation: ops.Relation) -> None:
+        """Store the app registration as a Juju secret.
+
+        Args:
+            model: the Juju model
+            relation: relation to grant access to the secrets to.
+        """
+        # password is always defined since pydantic guarantees it
+        password = cast(SecretStr, self.registration)
+        # pylint doesn't like get_secret_value
+        secret_value = password.get_secret_value()  # pylint: disable=no-member
+        try:
+            secret = model.get_secret(label=APP_REGISTRATION_LABEL)
+            secret.set_content({APP_REGISTRATION_CONTENT_LABEL: secret_value})
+            # secret.id is not None at this point
+            self.registration_secret_id = cast(str, secret.id)
+        except ops.SecretNotFoundError:
+            secret = relation.app.add_secret(
+                {APP_REGISTRATION_CONTENT_LABEL: secret_value}, label=APP_REGISTRATION_LABEL
+            )
+            secret.grant(relation)
+            self.registration_secret_id = cast(str, secret.id)
+
+    @classmethod
+    def get_registration(
+        cls, model: ops.Model, registration_secret_id: Optional[str]
+    ) -> Optional[SecretStr]:
+        """Retrieve the registration corresponding to the registration_secret_id.
+
+        Args:
+            model: the Juju model.
+            registration_secret_id: the secret ID for the registration.
+
+        Returns:
+            the registration or None if not found.
+        """
+        if not registration_secret_id:
+            return None
+        try:
+            secret = model.get_secret(id=registration_secret_id)
+            password = secret.get_content().get(APP_REGISTRATION_CONTENT_LABEL)
+            if not password:
+                return None
+            return SecretStr(password)
+        except ops.SecretNotFoundError:
+            return None
+
+    def to_relation_data(self, model: ops.Model, relation: ops.Relation) -> Dict[str, str]:
+        """Convert an instance of MatrixAuthRequirerData to the relation representation.
+
+        Args:
+            model: the Juju model.
+            relation: relation to grant access to the secrets to.
+
+        Returns:
+            Dict containing the representation.
+        """
+        self.set_registration_id(model, relation)
+        dumped_model = self.model_dump(exclude_unset=True)
+        dumped_data = {
+            "registration_secret_id": dumped_model["registration_secret_id"],
+        }
+        return dumped_data
+
+    @classmethod
+    def from_relation(cls, model: ops.Model, relation: ops.Relation) -> "MatrixAuthRequirerData":
+        """Get a MatrixAuthRequirerData from the relation data.
+
+        Args:
+            model: the Juju model.
+            relation: the relation.
+
+        Returns:
+            the relation data and the processed entries for it.
+
+        Raises:
+            ValueError: if the value is not parseable.
+        """
+        app = cast(ops.Application, relation.app)
+        relation_data = relation.data[app]
+        registration_secret_id = relation_data.get("registration_secret_id")
+        registration = MatrixAuthRequirerData.get_registration(model, registration_secret_id)
+        return MatrixAuthRequirerData(
+            registration=registration,
+        )
+
+
+#### Events ####
+class MatrixAuthRequestProcessed(ops.RelationEvent):
+    """MatrixAuth event emitted when a new request is processed."""
+
+    def get_matrix_auth_provider_relation_data(self) -> MatrixAuthProviderData:
+        """Get a MatrixAuthProviderData for the relation data.
+
+        Returns:
+            the MatrixAuthProviderData for the relation data.
+        """
+        return MatrixAuthProviderData.from_relation(self.framework.model, self.relation)
+
+
+class MatrixAuthRequestReceived(ops.RelationEvent):
+    """MatrixAuth event emitted when a new request is made."""
+
+
+class MatrixAuthRequiresEvents(ops.CharmEvents):
+    """MatrixAuth requirer events.
+
+    This class defines the events that a MatrixAuth requirer can emit.
+
+    Attributes:
+        matrix_auth_request_processed: the MatrixAuthRequestProcessed.
+    """
+
+    matrix_auth_request_processed = ops.EventSource(MatrixAuthRequestProcessed)
+
+
+class MatrixAuthProvidesEvents(ops.CharmEvents):
+    """MatrixAuth provider events.
+
+    This class defines the events that a MatrixAuth provider can emit.
+
+    Attributes:
+        matrix_auth_request_received: the MatrixAuthRequestReceived.
+    """
+
+    matrix_auth_request_received = ops.EventSource(MatrixAuthRequestReceived)
+
+
+#### Provides and Requires ####
+class MatrixAuthProvides(ops.Object):
+    """Provider side of the MatrixAuth relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = MatrixAuthProvidesEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_remote_relation_data(self) -> Optional[MatrixAuthRequirerData]:
+        """Retrieve the remote relation data.
+
+        Returns:
+            MatrixAuthRequirerData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return MatrixAuthRequirerData.from_relation(self.model, relation=relation) if relation else None
+
+    def _is_remote_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            _ = MatrixAuthRequirerData.from_relation(self.model, relation=relation)
+            return True
+        except ValueError as ex:
+            logger.warning("Error validating the relation data %s", ex)
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data and self._is_remote_relation_data_valid(event.relation):
+            self.on.matrix_auth_request_received.emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def update_relation_data(
+        self, relation: ops.Relation, matrix_auth_provider_data: MatrixAuthProviderData
+    ) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            matrix_auth_provider_data: a MatrixAuthProviderData instance wrapping the data to be
+                updated.
+        """
+        relation_data = matrix_auth_provider_data.to_relation_data(self.model, relation)
+        relation.data[self.model.app].update(relation_data)
+
+
+class MatrixAuthRequires(ops.Object):
+    """Requirer side of the MatrixAuth requires relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = MatrixAuthRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_remote_relation_data(self) -> Optional[MatrixAuthProviderData]:
+        """Retrieve the remote relation data.
+
+        Returns:
+            MatrixAuthProviderData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return MatrixAuthProviderData.from_relation(self.model, relation=relation) if relation else None
+
+    def _is_remote_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            _ = MatrixAuthProviderData.from_relation(self.model, relation=relation)
+            return True
+        except ValueError as ex:
+            logger.warning("Error validating the relation data %s", ex)
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data and self._is_remote_relation_data_valid(event.relation):
+            self.on.matrix_auth_request_processed.emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def update_relation_data(
+        self,
+        relation: ops.Relation,
+        matrix_auth_requirer_data: MatrixAuthRequirerData,
+    ) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            matrix_auth_requirer_data: MatrixAuthRequirerData wrapping the data to be updated.
+        """
+        relation_data = matrix_auth_requirer_data.to_relation_data(self.model, relation)
+        relation.data[self.model.app].update(relation_data)

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -16,7 +16,7 @@ Maubot charm service.
 ## <kbd>class</kbd> `MaubotCharm`
 Maubot charm. 
 
-<a href="../src/charm.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -74,8 +74,25 @@ Unit that this execution is responsible for.
 
 ---
 
-## <kbd>class</kbd> `MissingPostgreSQLRelationDataError`
-Custom exception to be raised in case of malformed/missing Postgresql relation data. 
+## <kbd>class</kbd> `MissingRelationDataError`
+Custom exception to be raised in case of malformed/missing relation data. 
+
+<a href="../src/charm.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(message: str, relation_name: str = '') → None
+```
+
+Init custom exception. 
+
+
+
+**Args:**
+ 
+ - <b>`message`</b>:  Exception message. 
+ - <b>`relation_name`</b>:  Relation name that raised the exception. 
 
 
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -92,7 +92,7 @@ Custom exception to be raised in case of malformed/missing relation data.
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(message: str, relation_name: str = '') → None
+__init__(message: str, relation_name: str) → None
 ```
 
 Init custom exception. 

--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,7 @@ class MaubotCharm(ops.CharmBase):
                     # See https://github.com/canonical/operator/issues/1310
                     pass
                 else:
-                    raise e from re
+                    raise re
             except (ops.pebble.ChangeError, ops.pebble.APIError) as pe:
                 logging.exception("failed to stop maubot", exc_info=pe)
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -185,7 +185,8 @@ class MaubotCharm(ops.CharmBase):
         """
         relation = self.model.get_relation("matrix-auth")
         if not relation or not relation.app:
-            raise MissingRelationDataError("No matrix relation data", relation_name="matrix-auth")
+            logging.warning("no matrix-auth relation found, getting default matrix credentials")
+            return {"matrix": {"url": "https://matrix-client.matrix.org", "secret": "null"}}
         relation_data = self.matrix_auth.get_remote_relation_data()
         homeserver = relation_data.homeserver
         shared_secret_id = relation_data.shared_secret.get_secret_value()

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ NGINX_NAME = "nginx"
 class MissingRelationDataError(Exception):
     """Custom exception to be raised in case of malformed/missing relation data."""
 
-    def __init__(self, message: str, relation_name: str = "") -> None:
+    def __init__(self, message: str, relation_name: str) -> None:
         """Init custom exception.
 
         Args:

--- a/src/charm.py
+++ b/src/charm.py
@@ -106,7 +106,7 @@ class MaubotCharm(ops.CharmBase):
                 container.stop(MAUBOT_NAME)
             except RuntimeError:
                 logging.info("maubot is not running, no action taken")
-            except ops.pebble.ChangeError as pe:
+            except (ops.pebble.ChangeError, ops.pebble.APIError) as pe:
                 logging.exception("failed to stop maubot", exc_info=pe)
             return
         container.add_layer(MAUBOT_NAME, self._pebble_layer, combine=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,8 +104,6 @@ class MaubotCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus(f"{e.relation_name} integration is required")
             try:
                 container.stop(MAUBOT_NAME)
-            except RuntimeError:
-                logging.info("maubot is not running, no action taken")
             except (ops.pebble.ChangeError, ops.pebble.APIError) as pe:
                 logging.exception("failed to stop maubot", exc_info=pe)
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseEndpointsChangedEvent,
     DatabaseRequires,
 )
+from charms.synapse.v0.matrix_auth import MatrixAuthRequestProcessed, MatrixAuthRequires
 from charms.traefik_k8s.v2.ingress import (
     IngressPerAppReadyEvent,
     IngressPerAppRequirer,
@@ -30,8 +31,18 @@ MAUBOT_NAME = "maubot"
 NGINX_NAME = "nginx"
 
 
-class MissingPostgreSQLRelationDataError(Exception):
-    """Custom exception to be raised in case of malformed/missing Postgresql relation data."""
+class MissingRelationDataError(Exception):
+    """Custom exception to be raised in case of malformed/missing relation data."""
+
+    def __init__(self, message: str, relation_name: str = "") -> None:
+        """Init custom exception.
+
+        Args:
+            message: Exception message.
+            relation_name: Relation name that raised the exception.
+        """
+        super().__init__(message)
+        self.relation_name = relation_name
 
 
 class MaubotCharm(ops.CharmBase):
@@ -48,6 +59,7 @@ class MaubotCharm(ops.CharmBase):
         self.postgresql = DatabaseRequires(
             self, relation_name="postgresql", database_name=self.app.name
         )
+        self.matrix_auth = MatrixAuthRequires(self)
         self.framework.observe(self.on.maubot_pebble_ready, self._on_maubot_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         # Integrations events handlers
@@ -55,6 +67,10 @@ class MaubotCharm(ops.CharmBase):
         self.framework.observe(self.postgresql.on.endpoints_changed, self._on_endpoints_changed)
         self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+        self.framework.observe(
+            self.matrix_auth.on.matrix_auth_request_processed,
+            self._on_matrix_auth_request_processed,
+        )
 
     def _configure_maubot(self, container: ops.Container) -> None:
         """Configure maubot.
@@ -72,6 +88,7 @@ class MaubotCharm(ops.CharmBase):
         config_content = str(container.pull("/data/config.yaml", encoding="utf-8").read())
         config = yaml.safe_load(config_content)
         config["database"] = self._get_postgresql_credentials()
+        config["homeservers"] = self._get_matrix_credentials()
         config["server"]["public_url"] = self.config.get("public-url")
         container.push("/data/config.yaml", yaml.safe_dump(config))
 
@@ -83,8 +100,14 @@ class MaubotCharm(ops.CharmBase):
             return
         try:
             self._configure_maubot(container)
-        except MissingPostgreSQLRelationDataError:
-            self.unit.status = ops.BlockedStatus("postgresql integration is required")
+        except MissingRelationDataError as e:
+            self.unit.status = ops.BlockedStatus(f"{e.relation_name} integration is required")
+            try:
+                container.stop(MAUBOT_NAME)
+            except RuntimeError:
+                logging.info("maubot is not running, no action taken")
+            except ops.pebble.ChangeError as pe:
+                logging.exception("failed to stop maubot", exc_info=pe)
             return
         container.add_layer(MAUBOT_NAME, self._pebble_layer, combine=True)
         container.restart(MAUBOT_NAME)
@@ -99,6 +122,7 @@ class MaubotCharm(ops.CharmBase):
         """Handle changed configuration."""
         self._reconcile()
 
+    # Integrations events handlers
     def _on_ingress_ready(self, _: IngressPerAppReadyEvent) -> None:
         """Handle ingress ready event."""
         self._reconcile()
@@ -107,13 +131,16 @@ class MaubotCharm(ops.CharmBase):
         """Handle ingress revoked event."""
         self._reconcile()
 
-    # Integrations events handlers
     def _on_database_created(self, _: DatabaseCreatedEvent) -> None:
         """Handle database created event."""
         self._reconcile()
 
     def _on_endpoints_changed(self, _: DatabaseEndpointsChangedEvent) -> None:
         """Handle endpoints changed event."""
+        self._reconcile()
+
+    def _on_matrix_auth_request_processed(self, _: MatrixAuthRequestProcessed) -> None:
+        """Handle matrix auth request processed event."""
         self._reconcile()
 
     # Relation data handlers
@@ -124,22 +151,49 @@ class MaubotCharm(ops.CharmBase):
             postgresql credentials.
 
         Raises:
-            MissingPostgreSQLRelationDataError: if relation is not found.
+            MissingRelationDataError: if relation is not found.
         """
         relation = self.model.get_relation("postgresql")
         if not relation or not relation.app:
-            raise MissingPostgreSQLRelationDataError("No postgresql relation data")
+            raise MissingRelationDataError(
+                "No postgresql relation data", relation_name="postgresql"
+            )
         endpoints = self.postgresql.fetch_relation_field(relation.id, "endpoints")
         database = self.postgresql.fetch_relation_field(relation.id, "database")
         username = self.postgresql.fetch_relation_field(relation.id, "username")
         password = self.postgresql.fetch_relation_field(relation.id, "password")
 
         if not endpoints:
-            raise MissingPostgreSQLRelationDataError("Missing mandatory relation data")
+            raise MissingRelationDataError(
+                "Missing mandatory relation data", relation_name="postgresql"
+            )
         primary_endpoint = endpoints.split(",")[0]
         if not all((primary_endpoint, database, username, password)):
-            raise MissingPostgreSQLRelationDataError("Missing mandatory relation data")
+            raise MissingRelationDataError(
+                "Missing mandatory relation data", relation_name="postgresql"
+            )
         return f"postgresql://{username}:{password}@{primary_endpoint}/{database}"
+
+    def _get_matrix_credentials(self) -> dict[str, dict[str, str]]:
+        """Get Matrix credentials from the matrix-auth integration.
+
+        Returns:
+            matrix credentials.
+
+        Raises:
+            MissingRelationDataError: if relation is not found.
+        """
+        relation = self.model.get_relation("matrix-auth")
+        if not relation or not relation.app:
+            raise MissingRelationDataError("No matrix relation data", relation_name="matrix-auth")
+        relation_data = self.matrix_auth.get_remote_relation_data()
+        homeserver = relation_data.homeserver
+        shared_secret_id = relation_data.shared_secret.get_secret_value()
+        if not all((homeserver, shared_secret_id)):
+            raise MissingRelationDataError(
+                "Missing mandatory relation data", relation_name="matrix-auth"
+            )
+        return {"synapse": {"url": homeserver, "secret": shared_secret_id}}
 
     # Properties
     @property

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,10 @@
 
 import ops
 import ops.testing
+import pytest
 from charms.synapse.v0.matrix_auth import MatrixAuthProviderData
+
+from charm import MissingRelationDataError
 
 
 def set_postgresql_integration(harness) -> None:
@@ -94,6 +97,8 @@ def test_database_created(harness):
     assert: postgresql credentials are set as expected.
     """
     harness.begin_with_initial_hooks()
+    with pytest.raises(MissingRelationDataError):
+        harness.charm._get_postgresql_credentials()
 
     set_postgresql_integration(harness)
 
@@ -122,11 +127,14 @@ def test_public_url_config_changed(harness, monkeypatch):
 
 def test_matrix_credentials_registered(harness, monkeypatch):
     """
-    arrange: initialize harness and verify that there is no credentials.
+    arrange: initialize harness and verify that the credentials are set with default values.
     act: set matrix-auth integration.
     assert: matrix credentials are set as expected.
     """
     harness.begin_with_initial_hooks()
+    assert harness.charm._get_matrix_credentials() == {
+        "matrix": {"secret": "null", "url": "https://matrix-client.matrix.org"}
+    }
 
     set_matrix_auth_integration(harness, monkeypatch)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,26 +33,6 @@ def set_postgresql_integration(harness) -> None:
     )
 
 
-def set_matrix_auth_integration(harness, monkeypatch) -> None:
-    """Set matrix-auth integration.
-
-    Args:
-        harness: harness instance.
-        monkeypatch: monkeypatch instance.
-    """
-    monkeypatch.setattr(
-        MatrixAuthProviderData, "get_shared_secret", lambda *args: "test-shared-secret"
-    )
-    relation_data = {"homeserver": "https://example.com", "shared_secret_id": "test-secret-id"}
-    matrix_relation_id = harness.add_relation("matrix-auth", "synapse", app_data=relation_data)
-    harness.add_relation_unit(matrix_relation_id, "synapse/0")
-    harness.update_relation_data(
-        matrix_relation_id,
-        "synapse",
-        relation_data,
-    )
-
-
 def test_maubot_pebble_ready_postgresql_required(harness):
     """
     arrange: initialize the testing harness with handle_exec and
@@ -153,3 +133,23 @@ def test_matrix_credentials_registered(harness, monkeypatch):
     assert harness.charm._get_matrix_credentials() == {
         "synapse": {"secret": "test-shared-secret", "url": "https://example.com"}
     }
+
+
+def set_matrix_auth_integration(harness, monkeypatch) -> None:
+    """Set matrix-auth integration.
+
+    Args:
+        harness: harness instance.
+        monkeypatch: monkeypatch instance.
+    """
+    monkeypatch.setattr(
+        MatrixAuthProviderData, "get_shared_secret", lambda *args: "test-shared-secret"
+    )
+    relation_data = {"homeserver": "https://example.com", "shared_secret_id": "test-secret-id"}
+    matrix_relation_id = harness.add_relation("matrix-auth", "synapse", app_data=relation_data)
+    harness.add_relation_unit(matrix_relation_id, "synapse/0")
+    harness.update_relation_data(
+        matrix_relation_id,
+        "synapse",
+        relation_data,
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,55 +5,12 @@
 
 """Unit tests."""
 
-from functools import wraps
-from typing import Any, Callable
-
 import ops
 import ops.testing
 import pytest
 from charms.synapse.v0.matrix_auth import MatrixAuthProviderData
 
 from charm import MissingRelationDataError
-
-
-def handle_runtime_exception(f: Callable[..., Any | None]) -> Callable[..., Any | None]:
-    """Handle RunTimeError raised by Harness when a service is not found.
-
-    This behavior is not expected in real environment.
-    For more details, see this issue:
-    https://github.com/canonical/operator/issues/1310
-
-    Args:
-        f (Callable[..., Any  |  None]): the unit test.
-
-    Returns:
-        Executed test.
-    """
-
-    @wraps(f)
-    def wrapper(*args, **kw) -> Any | None:
-        """Wrap the test function.
-
-        Args:
-            args: test arguments.
-            kw: keyword arguments to pass to the decorated function.
-
-        Raises:
-            e: Exception raised by the test.
-
-        Returns:
-            Executed test.
-        """
-        try:
-            return f(*args, **kw)
-        except RuntimeError as e:
-            if str(e) == '400 Bad Request: service "maubot" does not exist':
-                pass
-            else:
-                raise e
-        return None
-
-    return wrapper
 
 
 def set_postgresql_integration(harness) -> None:
@@ -79,7 +36,6 @@ def set_postgresql_integration(harness) -> None:
     )
 
 
-@handle_runtime_exception
 def test_maubot_pebble_ready_postgresql_required(harness):
     """
     arrange: initialize the testing harness with handle_exec and
@@ -134,7 +90,6 @@ def test_maubot_pebble_ready(harness):
     assert harness.model.unit.status == ops.ActiveStatus()
 
 
-@handle_runtime_exception
 def test_database_created(harness):
     """
     arrange: initialize harness and verify that there is no credentials.
@@ -153,7 +108,6 @@ def test_database_created(harness):
     )
 
 
-@handle_runtime_exception
 def test_public_url_config_changed(harness, monkeypatch):
     """
     arrange: initialize harness and set postgresql integration.
@@ -171,7 +125,6 @@ def test_public_url_config_changed(harness, monkeypatch):
     assert harness.model.unit.status == ops.ActiveStatus()
 
 
-@handle_runtime_exception
 def test_matrix_credentials_registered(harness, monkeypatch):
     """
     arrange: initialize harness and verify that the credentials are set with default values.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -80,8 +80,6 @@ def test_maubot_pebble_ready(harness, monkeypatch):
     harness.begin()
     harness.set_can_connect("maubot", True)
     set_postgresql_integration(harness)
-    assert harness.model.unit.status == ops.BlockedStatus("matrix-auth integration is required")
-    set_matrix_auth_integration(harness, monkeypatch)
 
     expected_plan = {
         "services": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,9 +44,7 @@ def set_matrix_auth_integration(harness, monkeypatch) -> None:
         MatrixAuthProviderData, "get_shared_secret", lambda *args: "test-shared-secret"
     )
     relation_data = {"homeserver": "https://example.com", "shared_secret_id": "test-secret-id"}
-    matrix_relation_id = harness.add_relation(  # pylint: disable=attribute-defined-outside-init
-        "matrix-auth", "synapse", app_data=relation_data
-    )
+    matrix_relation_id = harness.add_relation("matrix-auth", "synapse", app_data=relation_data)
     harness.add_relation_unit(matrix_relation_id, "synapse/0")
     harness.update_relation_data(
         matrix_relation_id,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,12 +5,55 @@
 
 """Unit tests."""
 
+from functools import wraps
+from typing import Any, Callable
+
 import ops
 import ops.testing
 import pytest
 from charms.synapse.v0.matrix_auth import MatrixAuthProviderData
 
 from charm import MissingRelationDataError
+
+
+def handle_runtime_exception(f: Callable[..., Any | None]) -> Callable[..., Any | None]:
+    """Handle RunTimeError raised by Harness when a service is not found.
+
+    This behavior is not expected in real environment.
+    For more details, see this issue:
+    https://github.com/canonical/operator/issues/1310
+
+    Args:
+        f (Callable[..., Any  |  None]): the unit test.
+
+    Returns:
+        Executed test.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kw) -> Any | None:
+        """Wrap the test function.
+
+        Args:
+            args: test arguments.
+            kw: keyword arguments to pass to the decorated function.
+
+        Raises:
+            e: Exception raised by the test.
+
+        Returns:
+            Executed test.
+        """
+        try:
+            return f(*args, **kw)
+        except RuntimeError as e:
+            if str(e) == '400 Bad Request: service "maubot" does not exist':
+                pass
+            else:
+                raise e
+        return None
+
+    return wrapper
 
 
 def set_postgresql_integration(harness) -> None:
@@ -36,6 +79,7 @@ def set_postgresql_integration(harness) -> None:
     )
 
 
+@handle_runtime_exception
 def test_maubot_pebble_ready_postgresql_required(harness):
     """
     arrange: initialize the testing harness with handle_exec and
@@ -90,6 +134,7 @@ def test_maubot_pebble_ready(harness):
     assert harness.model.unit.status == ops.ActiveStatus()
 
 
+@handle_runtime_exception
 def test_database_created(harness):
     """
     arrange: initialize harness and verify that there is no credentials.
@@ -108,6 +153,7 @@ def test_database_created(harness):
     )
 
 
+@handle_runtime_exception
 def test_public_url_config_changed(harness, monkeypatch):
     """
     arrange: initialize harness and set postgresql integration.
@@ -125,6 +171,7 @@ def test_public_url_config_changed(harness, monkeypatch):
     assert harness.model.unit.status == ops.ActiveStatus()
 
 
+@handle_runtime_exception
 def test_matrix_credentials_registered(harness, monkeypatch):
     """
     arrange: initialize harness and verify that the credentials are set with default values.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -69,7 +69,7 @@ def test_maubot_pebble_ready_postgresql_required(harness):
     assert harness.model.unit.status == ops.BlockedStatus("postgresql integration is required")
 
 
-def test_maubot_pebble_ready(harness, monkeypatch):
+def test_maubot_pebble_ready(harness):
     """
     arrange: initialize the testing harness with handle_exec and
         config.yaml file.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add matrix-auth integration that allows integrate Maubot with Synapse.


### Rationale

The first step to install a bot is create a client.

A client requires that the homeserver is configured in the Maubot configuration file.

Once is there, the user will run an action "register-client-account" that will create a user and return an access token and a device id.

See here for the entire flow:
https://docs.mau.fi/maubot/usage/basic.html#creating-clients

Extra:
- If the integrations PostgreSQL and/or matrix-auth relation data are not found, the charm is blocked and if the service is running, is stopped. Thanks @javierdelapuente for spotting this
- Integration test will be added once Synapse provides the matrix-auth endpoint.

### Juju Events Changes
_on_matrix_auth_request_processed

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->
Matrix auth library.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No CH available yet.
