### PR TITLE
chore: manage maubot updates via renovate

### DIFF
--- a/maubot_rock/rockcraft.yaml
+++ b/maubot_rock/rockcraft.yaml
@@ -4,7 +4,7 @@
 name: maubot
 summary: Maubot rock
 description: Maubot OCI image for the Maubot charm
-version: "0.5.0"
+version: 0.5.0
 license: Apache-2.0
 
 base: ubuntu@24.04

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,15 @@
       "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"],
       "datasourceTemplate": "docker",
       "versioningTemplate": "ubuntu"
+    },
+    {
+      "fileMatch": ["(^|/)rockcraft.yaml$"],
+      "description": "Update Maubot workload",
+      "matchStringsStrategy": "any",
+      "matchStrings": ["maubot==(?<currentValue>.+)", "version: (?<currentValue>.+)"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "maubot/maubot",
+      "versioningTemplate": "semver-coerced"
     }
   ],
   "packageRules": [
@@ -21,11 +30,6 @@
         "docker"
       ],
       "pinDigests": true
-    },
-    {
-      "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use Renovate to monitor new Maubot releases.

### Rationale

Keep workload updated.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No CH available.