### PR TITLE
fix: handle postgresql relation departed

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,7 @@ CVE-2024-34156
 # Blackbox Exporter CVEs - Go project issues
 CVE-2024-24790
 CVE-2024-24788
+# Blackbox
+CVE-2024-45337
+# Pebble
+CVE-2024-45338

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,6 +12,7 @@ Maubot charm service.
 - **MAUBOT_CONFIGURATION_PATH**
 - **MAUBOT_NAME**
 - **NGINX_NAME**
+- **POSTGRESQL_RELATION_NAME**
 
 
 ---
@@ -28,7 +29,7 @@ Exception raised when an event fails.
 ## <kbd>class</kbd> `MaubotCharm`
 Maubot charm. 
 
-<a href="../lib/charms/loki_k8s/v0/charm_logging.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../lib/charms/loki_k8s/v0/charm_logging.py#L74"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -89,7 +90,7 @@ Unit that this execution is responsible for.
 ## <kbd>class</kbd> `MissingRelationDataError`
 Custom exception to be raised in case of malformed/missing relation data. 
 
-<a href="../src/charm.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -74,7 +74,7 @@ def test_config_changed_with_postgresql(base_state: dict):
     """
     endpoints = "1.2.3.4:5432"
     username = "user"
-    password = "pass" # nosec
+    password = "pass"  # nosec
     database = "maubot"
     postgresql_relation = scenario.Relation(
         endpoint="postgresql",

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -1,0 +1,122 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the Maubot module using Scenario."""
+
+import textwrap
+from pathlib import Path
+
+import ops
+import pytest
+import scenario
+from scenario.context import _Event  # needed for custom events for now
+
+from charm import MaubotCharm
+
+
+@pytest.fixture(scope="function", name="base_state")
+def base_state_fixture(tmp_path: Path):
+    """State with container and config file set."""
+    config_file_path = tmp_path / "config.yaml"
+    config_file_path.write_text(
+        textwrap.dedent(
+            """
+        databases: null
+        server:
+            public_url: maubot.local
+        """
+        ),
+        encoding="utf-8",
+    )
+    yield {
+        "leader": True,
+        "containers": {
+            scenario.Container(
+                name="maubot",
+                can_connect=True,
+                execs={
+                    scenario.Exec(
+                        command_prefix=["cp"],
+                        return_code=0,
+                    ),
+                    scenario.Exec(
+                        command_prefix=["mkdir"],
+                        return_code=0,
+                    ),
+                },
+                mounts={
+                    "data": scenario.Mount(location="/data/config.yaml", source=config_file_path)
+                },
+            )
+        },
+    }
+
+
+def test_config_changed_no_postgresql(base_state: dict):
+    """
+    arrange: prepare maubot container.
+    act: run config_changed.
+    assert: status is blocked because there is no postgresql integration.
+    """
+    state = ops.testing.State(**base_state)
+    context = ops.testing.Context(
+        charm_type=MaubotCharm,
+    )
+    out = context.run(context.on.config_changed(), state)
+    assert out.unit_status == ops.testing.BlockedStatus("postgresql integration is required")
+
+
+def test_config_changed_with_postgresql(base_state: dict):
+    """
+    arrange: prepare maubot container.
+    act: run config_changed.
+    assert: status is blocked because there is no postgresql integration.
+    """
+    endpoints = "1.2.3.4:5432"
+    username = "user"
+    password = "pass" # nosec
+    database = "maubot"
+    postgresql_relation = scenario.Relation(
+        endpoint="postgresql",
+        interface="postgresql_client",
+        remote_app_name="postgresql",
+        remote_app_data={
+            "endpoints": endpoints,
+            "username": username,
+            "password": password,
+            "database": database,
+        },
+    )
+    base_state["relations"] = [postgresql_relation]
+    state = ops.testing.State(**base_state)
+    context = ops.testing.Context(
+        charm_type=MaubotCharm,
+    )
+    out = context.run(context.on.config_changed(), state)
+    assert out.unit_status == ops.testing.ActiveStatus()
+    container_root_fs = list(base_state["containers"])[0].get_filesystem(context)
+    config_file = container_root_fs / "data" / "config.yaml"
+    assert f"postgresql://{username}:{password}@{endpoints}/{database}" in config_file.read_text()
+
+
+def test_postgresql_relation_departed(base_state: dict):
+    """
+    arrange: prepare maubot container.
+    act: run config_changed.
+    assert: status is blocked because there is no postgresql integration.
+    """
+    postgresql_relation = scenario.Relation(
+        endpoint="postgresql",
+        interface="postgresql_client",
+        remote_app_name="postgresql",
+    )
+    base_state["relations"] = [postgresql_relation]
+    state = ops.testing.State(**base_state)
+    context = ops.testing.Context(
+        charm_type=MaubotCharm,
+    )
+    postgresql_relation_departed_event = _Event(
+        "postgresql_relation_departed", relation=postgresql_relation
+    )
+    out = context.run(postgresql_relation_departed_event, state)
+    assert out.unit_status == ops.testing.BlockedStatus("postgresql integration is required")

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     flake8-test-docs>=1.0
     isort
     mypy
+    ops-scenario
     pep8-naming
     pydocstyle>=2.10
     pylint
@@ -77,6 +78,7 @@ deps =
     pytest
     pytest_asyncio
     pytest_operator
+    ops-scenario
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     flake8-test-docs>=1.0
     isort
     mypy
-    ops-scenario
+    ops[testing]
     pep8-naming
     pydocstyle>=2.10
     pylint

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps =
     pytest
     pytest_asyncio
     pytest_operator
-    ops-scenario
+    ops[testing]
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Since postgresql integration is required, the charm should handle relation departed and block again.

Also:
* add new set of unit tests using Scenario.

### Rationale

Handle PostgreSQL relation departed.

### Juju Events Changes

PostgreSQL relation departed

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
