### PR TITLE
feat: add reset-admin-password action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -70,6 +70,12 @@ actions:
       name:
         type: string
         description: The name of the administrator user.
+  reset-admin-password:
+    description: Reset password for administrator user.
+    params:
+      name:
+        type: string
+        description: The name of the administrator user.
   register-client-account:
     description: Register Matrix client account for a bot. The result is user ID,
       password, access token and device ID that should be used for registering a

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -132,6 +132,45 @@ def test_create_admin_action_failed(harness):
         assert e.message == message
 
 
+def test_reset_admin_password_action_success(harness):
+    """
+    arrange: initialize the testing harness, set up all required integration
+        and create an admin user.
+    act: run reset-admin-password.
+    assert: ensure password is in the results.
+    """
+    harness.set_leader()
+    harness.begin_with_initial_hooks()
+    set_postgresql_integration(harness)
+    action = harness.run_action("create-admin", {"name": "test"})
+    assert "password" in action.results
+    assert "error" not in action.results
+
+    action = harness.run_action("reset-admin-password", {"name": "test"})
+
+    assert "password" in action.results
+    assert "error" not in action.results
+
+
+def test_reset_admin_password_action_failed(harness):
+    """
+    arrange: initialize the testing harness and set up all required integration.
+    act: run reset-admin-password.
+    assert: ensure action fails.
+    """
+    harness.set_leader()
+    harness.begin_with_initial_hooks()
+    set_postgresql_integration(harness)
+
+    username = "test"
+    try:
+        harness.run_action("reset-admin-password", {"name": username})
+    except ops.testing.ActionFailed as e:
+        message = f"{username} not found"
+        assert e.output.results["error"] == message
+        assert e.message == message
+
+
 def test_public_url_config_changed(harness, monkeypatch):
     """
     arrange: initialize harness and set postgresql integration.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This action resets the password for an existing user. Fails if the user is not found or if the value is root (reserved).

### Rationale

Provide a way of changing the admin password.

### Juju Events Changes

Observers new action.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
