### PR TITLE
docs/ISD-3482: Fix issues except Maubot for vale check

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,2 +1,3 @@
 Blackbox
+blackbox
 Maubot

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,2 @@
+Blackbox
+Maubot

--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,4 @@ CVE-2024-45337
 CVE-2025-22869
 # Pebble
 CVE-2024-45338
+CVE-2025-22874 # stdlib issue - fixed in v.1.24.4 (currently v.1.24.2)

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -40,6 +40,7 @@ The Maubot charm deploys a container named `maubot` with the following Pebble la
 
 3. blackbox: A [Prometheus blackbox exporter](https://github.com/prometheus/blackbox_exporter) instance that collects metrics from the Maubot HTTP endpoint.
 
+
 ## OCI images
 
 We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/)

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -81,7 +81,7 @@ The workload that this container is running is defined in the [Maubot rock](http
 ### Blackbox
 
 Blackbox is a Prometheus exporter used to collect metrics from HTTP, HTTPS, DNS, 
-TCP, ICMP, and gRPC endpoints. 
+TCP, ICMP, and gRPC endpoints.
 
 Using this exporter, it is possible to monitor Maubot's performance while
 handling HTTP requests.

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -37,10 +37,8 @@ The Maubot charm deploys a container named `maubot` with the following Pebble la
 1. maubot: This layer contains the Maubot application service.
 
 2. nginx: Configures NGINX to efficiently serve static resources and acts as the entry point for all web traffic to the pod.
-<!-- vale Canonical.000-US-spellcheck = off -->
-<!-- blackbox is the name of the app -->
+
 3. blackbox: A [Prometheus blackbox exporter](https://github.com/prometheus/blackbox_exporter) instance that collects metrics from the Maubot HTTP endpoint.
-<!-- vale Canonical.000-US-spellcheck = on -->
 
 ## OCI images
 
@@ -81,11 +79,10 @@ forward non-static traffic to it.
 The workload that this container is running is defined in the [Maubot rock](https://github.com/canonical/maubot-operator/tree/main/maubot_rock).
 
 ### Blackbox
-<!-- vale Canonical.000-US-spellcheck = off -->
-<!-- blackbox is the name of the app -->
+
 Blackbox is a Prometheus exporter used to collect metrics from HTTP, HTTPS, DNS, 
 TCP, ICMP, and gRPC endpoints. 
-<!-- vale Canonical.000-US-spellcheck = on -->
+
 Using this exporter, it is possible to monitor Maubot's performance while
 handling HTTP requests.
 

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -5,7 +5,7 @@ It integrates with [PostgreSQL](https://www.postgresql.org/) as its database,
 which is provided by the [PostgreSQL charm](https://charmhub.io/postgresql).
 
 The Maubot charm can be integrated with the [Synapse charm](https://charmhub.io/synapse), enabling bot
-installation and usage on the existing Matrix homeserver.
+installation and usage on the existing Matrix home server.
 
 Pebble is a lightweight, API-driven process supervisor that is responsible for
 configuring processes to run in a container and controlling those processes
@@ -37,9 +37,10 @@ The Maubot charm deploys a container named `maubot` with the following Pebble la
 1. maubot: This layer contains the Maubot application service.
 
 2. nginx: Configures NGINX to efficiently serve static resources and acts as the entry point for all web traffic to the pod.
-
+<!-- vale Canonical.000-US-spellcheck = off -->
+<!-- blackbox is the name of the app -->
 3. blackbox: A [Prometheus blackbox exporter](https://github.com/prometheus/blackbox_exporter) instance that collects metrics from the Maubot HTTP endpoint.
-
+<!-- vale Canonical.000-US-spellcheck = on -->
 
 ## OCI images
 
@@ -55,7 +56,10 @@ This is done by publishing a resource to Charmhub as described in the
 Configuration files for the container can be found in the respective
 directory that define the rock.
 
+<!-- vale Canonical.007-Headings-sentence-case = off -->
+<!-- it is commonly stylized all uppercase -->
 ### NGINX
+<!-- vale Canonical.007-Headings-sentence-case = on -->
 
 NGINX is configured as a Pebble layer and is the entry point for all web traffic
 to the pod (on port `8080`). It serves static files directly and forwards
@@ -77,10 +81,11 @@ forward non-static traffic to it.
 The workload that this container is running is defined in the [Maubot rock](https://github.com/canonical/maubot-operator/tree/main/maubot_rock).
 
 ### Blackbox
-
-Blackbox is a Prometheus exporter used to collect metrics from HTTP, HTTPS, DNS,
-TCP, ICMP, and gRPC endpoints.
-
+<!-- vale Canonical.000-US-spellcheck = off -->
+<!-- blackbox is the name of the app -->
+Blackbox is a Prometheus exporter used to collect metrics from HTTP, HTTPS, DNS, 
+TCP, ICMP, and gRPC endpoints. 
+<!-- vale Canonical.000-US-spellcheck = on -->
 Using this exporter, it is possible to monitor Maubot's performance while
 handling HTTP requests.
 


### PR DESCRIPTION
Applicable ticket: ISD-3482

### Overview

Fixing documentation issues found by Vale. 

### Rationale

Fixing the spellchecks. This doesn't fix errors caused by word "Maubot", instead there is a [PR](https://github.com/canonical/praecepta/pull/118) I am waiting for to be merged that will include it.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
