### PR TITLE
Use new team name in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 *       @amandahla  @DeeKay3 @srbouffard @nrobinaubertin
 docs/*	@erinecon
 docs/changelog.md @amandahla  @DeeKay3 @srbouffard @nrobinaubertin
-requirements.txt	@canonical/is-charms
+requirements.txt	@canonical/platform-engineering


### PR DESCRIPTION
Replace references to is-charms to platform-engineering in CODEOWNERS