### PR TITLE
Add terraform module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-09-23
+
+- Add terraform module.
+
 ### 2025-06-10
 
 - Add changelog for tracking user-relevant changes.

--- a/terraform-docs.yaml
+++ b/terraform-docs.yaml
@@ -1,0 +1,15 @@
+name: Update Terraform documentation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  terraform-docs:
+    name: Update Terraform documentation
+    uses: canonical/operator-workflows/.github/workflows/generate_terraform_docs.yaml@main
+    secrets: inherit
+    with:
+      terraform-directory: terraform,terraform/tests

--- a/terraform-docs.yaml
+++ b/terraform-docs.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Update Terraform documentation
 
 on:

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,0 +1,3 @@
+rule "terraform_required_version" {
+  enabled = false
+}

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 rule "terraform_required_version" {
   enabled = false
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,42 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.20.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.20.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [juju_application.maubot](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application in the Juju model. | `string` | `"maubot"` | no |
+| <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy | `string` | `"ubuntu@22.04"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | The channel to use when deploying a charm. | `string` | `"latest/stable"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Application config. | `map(string)` | `{}` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to a `juju_model`. | `string` | `""` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm. | `number` | `null` | no |
+| <a name="input_units"></a> [units](#input\_units) | Number of units to deploy. | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | Name of the deployed application. |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "maubot" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "maubot"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config = var.config
+  units  = var.units
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,34 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.maubot.name
+}
+
+output "requires" {
+  value = {
+    ingress     = "ingress"
+    logging     = "logging"
+    matrix_auth = "matrix-auth"
+    postgresql  = "postgresql"
+  }
+}
+
+output "provides" {
+  value = {
+    grafana_dashboard = "grafana-dashboard"
+    metrics_endpoint  = "metrics-endpoint"
+  }
+}
+
+output "endpoints" {
+  value = {
+    grafana_dashboard = "grafana-dashboard"
+    ingress           = "ingress"
+    logging           = "logging"
+    matrix_auth       = "matrix-auth"
+    metrics_endpoint  = "metrics-endpoint"
+    postgresql        = "postgresql"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "maubot"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "config" {
+  description = "Application config."
+  type        = map(string)
+  default     = {}
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "revision" {
+  description = "Revision number of the charm."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.20.0"
+    }
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = ">= 0.22.0"
     }
   }
 }

--- a/test_terraform_files.yaml
+++ b/test_terraform_files.yaml
@@ -1,0 +1,52 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Test terraform files
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate terraform configuration files
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIR: 'terraform'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5.0.0
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+
+      - name: Run terraform fmt
+        run: terraform fmt -check -recursive
+        working-directory: ${{env.WORKING_DIR}}
+
+      - name: Setup Tflint
+        uses: terraform-linters/setup-tflint@v5.0.0
+        with:
+          tflint_wrapper_enabled: true
+
+      - name: Run tflint
+        run: |
+          tflint --version
+          tflint --init
+          tflint -f compact --recursive
+        working-directory: ${{env.WORKING_DIR}}
+
+  required_status_checks:
+    name: Required Terraform Validate Status Checks
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    steps:
+      - run: |
+          [ '${{ needs.validate.result }}' = 'success' ] || (echo validate failed && false)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add terraform module.

### Rationale

Provide Maubot via terraform.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->
