### PR TITLE
chore(terraform): align with current terraform standards (charmkeeper)

### DIFF
--- a/.github/workflows/test_terraform_module.yaml
+++ b/.github/workflows/test_terraform_module.yaml
@@ -1,0 +1,18 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Terraform modules tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+jobs:
+  terraform-tests:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
+    secrets: inherit
+    with:
+      k8s-controller: true
+      terraform-directories: '["terraform"]'

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
+  "customDatasources": {
+    "charmhub": {
+      "defaultRegistryUrlTemplate": "https://api.charmhub.io/v2/charms/info/{{packageName}}?fields=channel-map",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": $string($$.(`channel-map`[channel.risk = 'edge' and channel.track = 'latest' and channel.base.architecture = 'amd64' and channel.base.channel = '24.04'].revision.revision))}]}"
+      ]
+    }
+  },
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [],
   "packageRules": [
     {
       "enabled": true,
@@ -11,6 +21,13 @@
         "docker"
       ],
       "pinDigests": true
+    },
+    {
+      "automerge": true,
+      "enabled": true,
+      "matchDatasources": [
+        "custom.charmhub"
+      ]
     }
   ],
   "regexManagers": [
@@ -53,6 +70,18 @@
         "blackbox_exporter-(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "matchStringsStrategy": "any",
+      "versioningTemplate": "semver-coerced"
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "custom.charmhub",
+      "fileMatch": [
+        "\\.tftest\\.hcl$",
+        "\\.tf$"
+      ],
+      "matchStrings": [
+        "# renovate: depName=\"(?<packageName>[^\"]+)\"\\s*\\n\\s*(?<fieldName>[a-zA-Z0-9_]+)\\s*=\\s*(?<currentValue>\\d+)"
+      ],
       "versioningTemplate": "semver-coerced"
     }
   ]

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -2,5 +2,5 @@
 # See LICENSE file for licensing details.
 
 rule "terraform_required_version" {
-  enabled = false
+  enabled = true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@
 
 resource "juju_application" "maubot" {
   name  = var.app_name
-  model = var.model
+  model = var.model_uuid
 
   charm {
     name     = "maubot"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@
 
 resource "juju_application" "maubot" {
   name  = var.app_name
-  model = var.model_uuid
+  model_uuid = var.model_uuid
 
   charm {
     name     = "maubot"

--- a/terraform/tests/.tflint.hcl
+++ b/terraform/tests/.tflint.hcl
@@ -1,0 +1,3 @@
+rule "terraform_required_version" {
+  enabled = true
+}

--- a/terraform/tests/.tflint.hcl
+++ b/terraform/tests/.tflint.hcl
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 rule "terraform_required_version" {
   enabled = true
 }

--- a/terraform/tests/main.tftest.hcl
+++ b/terraform/tests/main.tftest.hcl
@@ -1,0 +1,22 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "basic_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    channel    = "latest/edge"
+    # renovate: depName="maubot"
+    revision = 92
+  }
+
+  assert {
+    condition     = output.app_name == "maubot"
+    error_message = "maubot app_name did not match expected"
+  }
+}

--- a/terraform/tests/setup/main.tf
+++ b/terraform/tests/setup/main.tf
@@ -1,0 +1,22 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+resource "juju_model" "test_model" {
+  name = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+output "model_uuid" {
+  value = juju_model.test_model.uuid
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,8 +25,8 @@ variable "config" {
   default     = {}
 }
 
-variable "model" {
-  description = "Reference to a `juju_model`."
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy the application into."
   type        = string
   default     = ""
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,10 +2,11 @@
 # See LICENSE file for licensing details.
 
 terraform {
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.22.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
This PR fixes the Terraform module for `maubot-operator` to align with current standards.

## Changes
- Rename `model` variable → `model_uuid`
- Fix Juju provider version: `>= 0.22.0` → `~> 1.0`
- Add `required_version = "~> 1.12"`
- Enable `terraform_required_version` tflint rule
- Add `terraform/tests/` with `setup/main.tf` and `main.tftest.hcl` (revision 92, `latest/edge`)
- Add `.github/workflows/test_terraform_module.yaml` CI workflow
- Update `renovate.json`: add CharmHub datasource, regex manager, `ignorePaths: []`

_Automated by [charmkeeper](https://github.com/seb4stien/charmkeeper)_