### PR TITLE
chore: add PR write permissions to bot_pr_approval.yaml

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -3,6 +3,9 @@ name: Provide approval for bot PRs
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+
 jobs:
   bot_pr_approval:
     uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main


### PR DESCRIPTION
This PR grants `pull-requests: write` permissions to the `bot_pr_approval.yaml` workflow so that bot PRs no longer fail the "Approve bot PR" check.